### PR TITLE
ctf: fix ctf-sequence-empty trace duration

### DIFF
--- a/ctf/src/main/java/org/eclipse/tracecompass/testtraces/ctf/CtfTestTrace.java
+++ b/ctf/src/main/java/org/eclipse/tracecompass/testtraces/ctf/CtfTestTrace.java
@@ -519,10 +519,10 @@ public enum CtfTestTrace {
      * Trace Size: 58.0 kB
      * Tracer: lttng-ust 2.13.5
      * Event count: 10
-     * Trace length: ~1.12 s
+     * Trace length: ~0.054627 ms
      * </pre>
      */
-    CTF_SEQUENCE_EMPTY("/ctf-sequence-empty", 10, 2);
+    CTF_SEQUENCE_EMPTY("/ctf-sequence-empty", 10, 1);
 
     private final String fTraceName;
     private final int fNbEvent;


### PR DESCRIPTION
Testing `org.eclipse.tracecompass.ctf.core.tests.trace.TraceReadAllTracesTest` fails due to the `CtfTestTrace.CTF_SEQUENCE_EMPTY` trace duration. It turns out that `babeltrace` 1.5 gives invalid timestamps due to the trace reading issue (https://github.com/eclipse-tracecompass/org.eclipse.tracecompass/issues/58):

```
$ babeltrace ctf/src/main/resources/ctf-sequence-empty/
[11:07:03.838013365] (+?.?????????) ade my_provider:my_sequence_tp: { cpu_id = 6 }, { _seq_length = 0, seq = [ ] }
[11:07:04.258920235] (+0.420906870) ade my_provider:my_sequence_tp: { cpu_id = 6 }, { _seq_length = 0, seq = [ ] }
[11:07:04.258920235] (+0.000000000) ade my_provider:my_sequence_tp: { cpu_id = 6 }, { _seq_length = 0, seq = [ ] }
[11:07:04.258920235] (+0.000000000) ade my_provider:my_sequence_tp: { cpu_id = 6 }, { _seq_length = 0, seq = [ ] }
[11:07:04.258920235] (+0.000000000) ade my_provider:my_sequence_tp: { cpu_id = 6 }, { _seq_length = 0, seq = [ ] }
[11:07:04.258920235] (+0.000000000) ade my_provider:my_sequence_tp: { cpu_id = 6 }, { _seq_length = 0, seq = [ ] }
[11:07:04.258920235] (+0.000000000) ade my_provider:my_sequence_tp: { cpu_id = 6 }, { _seq_length = 0, seq = [ ] }
[11:07:04.258920235] (+0.000000000) ade my_provider:my_sequence_tp: { cpu_id = 6 }, { _seq_length = 0, seq = [ ] }
[11:07:04.258920235] (+0.000000000) ade my_provider:my_sequence_tp: { cpu_id = 6 }, { _seq_length = 0, seq = [ ] }
[11:07:04.258920235] (+0.000000000) ade my_provider:my_sequence_tp: { cpu_id = 6 }, { _seq_length = 0, seq = [ ] }
[error] Unexpected end of packet. Either the trace data stream is corrupted or metadata description does not match data layout.
[error] Reading event failed.
Error printing trace.

```

`babeltrace2` works fine, so use that instead to get the trace length:

```
$ babeltrace2 ctf/src/main/resources/ctf-sequence-empty/
[11:07:03.838013365] (+?.?????????) ade my_provider:my_sequence_tp: { cpu_id = 6 }, { _seq_length = 0, seq = [ ] }
[11:07:03.838034582] (+0.000021217) ade my_provider:my_sequence_tp: { cpu_id = 6 }, { _seq_length = 0, seq = [ ] }
[11:07:03.838039990] (+0.000005408) ade my_provider:my_sequence_tp: { cpu_id = 6 }, { _seq_length = 0, seq = [ ] }
[11:07:03.838044055] (+0.000004065) ade my_provider:my_sequence_tp: { cpu_id = 6 }, { _seq_length = 0, seq = [ ] }
[11:07:03.838048055] (+0.000004000) ade my_provider:my_sequence_tp: { cpu_id = 6 }, { _seq_length = 0, seq = [ ] }
[11:07:03.838052023] (+0.000003968) ade my_provider:my_sequence_tp: { cpu_id = 6 }, { _seq_length = 0, seq = [ ] }
[11:07:03.838056023] (+0.000004000) ade my_provider:my_sequence_tp: { cpu_id = 6 }, { _seq_length = 0, seq = [ ] }
[11:07:03.838059992] (+0.000003969) ade my_provider:my_sequence_tp: { cpu_id = 6 }, { _seq_length = 0, seq = [ ] }
[11:07:03.838064024] (+0.000004032) ade my_provider:my_sequence_tp: { cpu_id = 6 }, { _seq_length = 0, seq = [ ] }
[11:07:03.838067992] (+0.000003968) ade my_provider:my_sequence_tp: { cpu_id = 6 }, { _seq_length = 0, seq = [ ] }
```

The trace length is ~0.054627 ms, not ~1.12 s. From what I understand, we can just round up to 1 second.